### PR TITLE
Feature: PSA-1712 create radio button controller

### DIFF
--- a/apps/web/src/components/Inputs/RadioButtonController/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/web/src/components/Inputs/RadioButtonController/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RadioButtonController should render the component 1`] = `
+<div>
+  <div
+    class="MuiFormControl-root css-1nrlq1o-MuiFormControl-root"
+  >
+    <label
+      class="MuiFormLabel-root MuiFormLabel-colorPrimary css-u4tvz2-MuiFormLabel-root"
+      id="test-label"
+    >
+      Test
+    </label>
+    <div
+      aria-labelledby="test-label"
+      class="MuiFormGroup-root css-dmmspl-MuiFormGroup-root"
+      role="radiogroup"
+    >
+      <label
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+      >
+        <span
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-vqmohf-MuiButtonBase-root-MuiRadio-root"
+        >
+          <input
+            class="PrivateSwitchBase-input css-1m9pwf3"
+            name="test"
+            type="radio"
+            value="test"
+          />
+          <span
+            class="css-hyxlzm"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+              data-testid="RadioButtonUncheckedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+              data-testid="RadioButtonCheckedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+        >
+          Test1
+        </span>
+      </label>
+      <label
+        class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-j204z7-MuiFormControlLabel-root"
+      >
+        <span
+          class="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary css-vqmohf-MuiButtonBase-root-MuiRadio-root"
+        >
+          <input
+            class="PrivateSwitchBase-input css-1m9pwf3"
+            name="test"
+            type="radio"
+            value="test2"
+          />
+          <span
+            class="css-hyxlzm"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hbvpl3-MuiSvgIcon-root"
+              data-testid="RadioButtonUncheckedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1hhw7if-MuiSvgIcon-root"
+              data-testid="RadioButtonCheckedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+              />
+            </svg>
+          </span>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </span>
+        <span
+          class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-ahj2mt-MuiTypography-root"
+        >
+          Test2
+        </span>
+      </label>
+    </div>
+    <p
+      class="MuiFormHelperText-root MuiFormHelperText-sizeMedium MuiFormHelperText-contained css-1wc848c-MuiFormHelperText-root"
+    />
+  </div>
+</div>
+`;

--- a/apps/web/src/components/Inputs/RadioButtonController/__tests__/index.spec.tsx
+++ b/apps/web/src/components/Inputs/RadioButtonController/__tests__/index.spec.tsx
@@ -1,0 +1,60 @@
+import { useForm } from 'react-hook-form'
+import RadioButtonController from '..'
+import { render, renderHook, RenderResult } from '@testing-library/react'
+
+describe('RadioButtonController', () => {
+	let wrapper: RenderResult
+
+	beforeEach(() => {
+		const { result } = renderHook(() => useForm())
+		wrapper = render(
+			<RadioButtonController
+				control={result.current.control}
+				label='Test'
+				name='test'
+				options={[
+					{ value: 'test', label: 'Test1' },
+					{ value: 'test2', label: 'Test2' }
+				]}
+			/>
+		)
+	})
+
+	afterEach(() => {
+		wrapper.unmount()
+	})
+
+	it('should render the component', () => {
+		expect(wrapper.container).toMatchSnapshot()
+	})
+
+	it('should display helper text when there is an error in input', () => {
+		const { result } = renderHook(() => useForm())
+		result.current.setError('test', {
+			type: 'manual',
+			message: 'Invalid Test'
+		})
+		wrapper = render(
+			<RadioButtonController
+				control={result.current.control}
+				label='Test'
+				name='test'
+				options={[
+					{ value: 'test', label: 'Test1' },
+					{ value: 'test2', label: 'Test2' }
+				]}
+			/>
+		)
+
+		expect(wrapper.getByText('Invalid Test')).toBeInTheDocument()
+	})
+
+	it('should display the label', () => {
+		expect(wrapper.getByText('Test')).toBeInTheDocument()
+	})
+
+	it('should display the options', () => {
+		expect(wrapper.getByText('Test1')).toBeInTheDocument()
+		expect(wrapper.getByText('Test2')).toBeInTheDocument()
+	})
+})

--- a/apps/web/src/components/Inputs/RadioButtonController/index.tsx
+++ b/apps/web/src/components/Inputs/RadioButtonController/index.tsx
@@ -1,0 +1,49 @@
+import {
+	FormControl,
+	FormControlLabel,
+	FormHelperText,
+	FormLabel,
+	Radio,
+	RadioGroup
+} from '@mui/material'
+import { Controller, FieldValues } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { Props } from './interfaces'
+
+export default function RadioButtonController<
+	T extends FieldValues = FieldValues
+>({ control, label, name, options, ...props }: Props<T>) {
+	const { t } = useTranslation()
+	return (
+		<FormControl {...props}>
+			<FormLabel id={`${name}-label`}>{label}</FormLabel>
+			<Controller
+				control={control}
+				name={name}
+				render={({ field, fieldState }) => (
+					<>
+						<RadioGroup
+							aria-labelledby={`${name}-label`}
+							name={name}
+							value={field.value}
+							onChange={field.onChange}>
+							{options.map((option) => (
+								<FormControlLabel
+									key={option.value}
+									value={option.value}
+									control={<Radio />}
+									label={t(option.label)}
+								/>
+							))}
+						</RadioGroup>
+						<FormHelperText>
+							{fieldState.error?.message
+								? t(fieldState.error.message)
+								: ''}
+						</FormHelperText>
+					</>
+				)}
+			/>
+		</FormControl>
+	)
+}

--- a/apps/web/src/components/Inputs/RadioButtonController/interfaces/index.ts
+++ b/apps/web/src/components/Inputs/RadioButtonController/interfaces/index.ts
@@ -1,0 +1,15 @@
+import { FormControlProps } from '@mui/material'
+import { Control, FieldValues, Path } from 'react-hook-form'
+
+export interface Props<T extends FieldValues = FieldValues>
+	extends FormControlProps {
+	readonly control: Control<T> | undefined
+	readonly name: Path<T>
+	readonly label: string
+	readonly options: RadioButtonOptions[]
+}
+
+export interface RadioButtonOptions {
+	readonly label: string
+	readonly value: string
+}


### PR DESCRIPTION
https://misoteam-proyecto.atlassian.net/browse/PSA-172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Nuevas Características**
    - Añadido un componente `RadioButtonController` que gestiona entradas de botones de radio con soporte para etiquetas y manejo de errores, utilizando componentes de Material-UI y traducción i18n.
- **Pruebas**
    - Implementadas pruebas para verificar la renderización del componente, la visualización de texto de ayuda en caso de error, y la correcta muestra de etiquetas y opciones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->